### PR TITLE
Reduce default session id length to 32

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "typed-session"
 version = "0.1.0-alpha.13"
-license = "MIT OR Apache-2.0"
+license = "BSD-2-Clause"
 repository = "https://github.com/ISibboI/typed-session"
 documentation = "https://docs.rs/typed-session"
 description = "Async typed session middleware"

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 [![Downloads](https://img.shields.io/crates/d/typed-session.svg?style=flat-square)](https://crates.io/crates/typed-session)
 [![Docs](https://img.shields.io/badge/docs-latest-blue.svg?style=flat-square)](https://docs.rs/typed-session)
 
-Use typed-session to outsource all the low-level details of session management, such as session expiration and automatic renewal as well as change tracking of session data.
-Typed-session was designed with **security**, **efficiency** and **usability** in mind.
+Use typed-session to outsource all the low-level details of session management, such as session **expiration** and automatic **renewal** as well as **change tracking** of session data.
+Typed-session was designed to live up to the [The OWASP® Foundation's](https://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html) session **security** standards, with **efficiency** and **usability** in mind.
 Typed session is meant to act as a middleware in a web framework, injecting session information into HTTP requests as required, and storing sessions in a database.
 
 The documentation is available on [docs.rs](https://docs.rs/typed-session).

--- a/README.md
+++ b/README.md
@@ -1,59 +1,36 @@
-<h1 align="center">typed-session</h1>
-<div align="center">
-  <strong>
-    Async typed session middleware
-  </strong>
-</div>
+# Async Typed Session Management in Rust
 
-<br />
-
-<div align="center">
-  <!-- Crates version -->
-  <a href="https://crates.io/crates/typed-session">
-    <img src="https://img.shields.io/crates/v/typed-session.svg?style=flat-square"
-    alt="Crates.io version" />
-  </a>
-  <!-- Downloads -->
-  <a href="https://crates.io/crates/typed-session">
-    <img src="https://img.shields.io/crates/d/typed-session.svg?style=flat-square"
-      alt="Download" />
-  </a>
-  <!-- docs.rs docs -->
-  <a href="https://docs.rs/typed-session">
-    <img src="https://img.shields.io/badge/docs-latest-blue.svg?style=flat-square"
-      alt="docs.rs docs" />
-  </a>
-</div>
-
-<div align="center">
-  <h3>
-    <a href="https://docs.rs/typed-session">
-      API Docs
-    </a>
-    <span> | </span>
-    <a href="https://github.com/ISibboI/typed-session/blob/main/.github/CONTRIBUTING.md">
-      Contributing
-    </a>
-  </h3>
-</div>
+[![Version](https://img.shields.io/crates/v/typed-session.svg?style=flat-square)](https://crates.io/crates/typed-session)
+[![Downloads](https://img.shields.io/crates/d/typed-session.svg?style=flat-square)](https://crates.io/crates/typed-session)
+[![Docs](https://img.shields.io/badge/docs-latest-blue.svg?style=flat-square)](https://docs.rs/typed-session)
 
 ## Available session stores
 
-* none so far
+ * none so far
 
 ## Framework implementations
 
-* none so far
+ * none so far
 
-## Safety
-This crate uses ``#![deny(unsafe_code)]`` to ensure everything is implemented in 100% Safe Rust.
+## Security
+
+We have designed and implemented the crate with security in mind.
+Our design fulfils the requirements stated in [The OWASP® Foundation](https://owasp.org)'s cheat sheet on [session management](https://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html).
+We additionally hash the session ids using the fast and secure hash function [blake3](https://en.wikipedia.org/wiki/BLAKE_(hash_function)#BLAKE3) before storing them.
+To mitigate exploitable bugs we use ``#![deny(unsafe_code)]`` to ensure everything is implemented in 100% safe Rust.
+
+So far, this crate has not been reviewed for security.
+If you have the necessary skills and wish to contribute to an open source project, please get in touch.
 
 ## Contributing
+
 Want to join us? Check out our ["Contributing" guide][contributing] and take a
 look at some of these issues:
 
 - [Issues labeled "good first issue"][good-first-issue]
 - [Issues labeled "help wanted"][help-wanted]
+
+Any contribution you intentionally submit for inclusion in the work, shall be licensed under the [BSD-2-Clause](https://opensource.org/license/bsd-2-clause/) license.
 
 [contributing]: https://github.com/http-rs/typed-session/blob/main/.github/CONTRIBUTING.md
 [good-first-issue]: https://github.com/http-rs/typed-session/labels/good%20first%20issue
@@ -67,15 +44,4 @@ This work is based on the crate [async-session](https://crates.io/crate/async-se
 
 ## License
 
-<sup>
-Licensed under either of <a href="LICENSE-APACHE">Apache License, Version
-2.0</a> or <a href="LICENSE-MIT">MIT license</a> at your option.
-</sup>
-
-<br/>
-
-<sub>
-Unless you explicitly state otherwise, any contribution intentionally submitted
-for inclusion in this crate by you, as defined in the Apache-2.0 license, shall
-be dual licensed as above, without any additional terms or conditions.
-</sub>
+This crate is licensed under the [BSD-2-Clause](https://opensource.org/license/bsd-2-clause/) license.

--- a/README.md
+++ b/README.md
@@ -4,11 +4,14 @@
 [![Downloads](https://img.shields.io/crates/d/typed-session.svg?style=flat-square)](https://crates.io/crates/typed-session)
 [![Docs](https://img.shields.io/badge/docs-latest-blue.svg?style=flat-square)](https://docs.rs/typed-session)
 
-## Available session stores
+Use typed-session to outsource all the low-level details of session management, such as session expiration and automatic renewal as well as change tracking of session data.
+Typed-session was designed with security, efficiency and usability in mind.
 
- * none so far
+Currently, the following session stores are available:
 
-## Framework implementations
+ * `MemoryStore`, a debug session store available under the feature flag `memory-store`.
+
+Currently, typed-session is integrated into the following web frameworks:
 
  * none so far
 

--- a/README.md
+++ b/README.md
@@ -4,11 +4,15 @@
 [![Downloads](https://img.shields.io/crates/d/typed-session.svg?style=flat-square)](https://crates.io/crates/typed-session)
 [![Docs](https://img.shields.io/badge/docs-latest-blue.svg?style=flat-square)](https://docs.rs/typed-session)
 
+API documentation: [docs.rs](https://docs.rs/typed-session)
+
 Use typed-session to outsource all the low-level details of session management, such as session **expiration** and automatic **renewal** as well as **change tracking** of session data.
 Typed-session was designed to live up to the [The OWASP® Foundation's](https://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html) session **security** standards, with **efficiency** and **usability** in mind.
-Typed session is meant to act as a middleware in a web framework, injecting session information into HTTP requests as required, and storing sessions in a database.
+With typed-session, you can take full advantage of Rust's type system to model your users' sessions.
 
-The documentation is available on [docs.rs](https://docs.rs/typed-session).
+## Compatibility
+
+Typed session acts as a middleware in a web framework, injecting session information into HTTP requests as required, and storing sessions in a database.
 
 Currently, the following **session stores** are available:
 
@@ -18,12 +22,16 @@ Currently, typed-session is integrated into the following **web frameworks**:
 
  * none so far
 
+Typed-session has no dependency to any specific async runtime, and hence can be used with any.
+
 ## Security
 
 We have designed and implemented the crate with security in mind.
 Our design fulfils the requirements stated in [The OWASP® Foundation](https://owasp.org)'s cheat sheet on [session management](https://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html).
 We additionally hash the session ids using the fast and secure hash function [blake3](https://en.wikipedia.org/wiki/BLAKE_(hash_function)#BLAKE3) before storing them.
 To mitigate exploitable bugs we use ``#![deny(unsafe_code)]`` to ensure everything is implemented in 100% safe Rust.
+
+For further details, refer to the [crate-level documentation](https://docs.rs/typed-session).
 
 So far, this crate has not been reviewed for security.
 If you have the necessary skills and wish to contribute to an open source project, please get in touch.

--- a/README.md
+++ b/README.md
@@ -5,13 +5,16 @@
 [![Docs](https://img.shields.io/badge/docs-latest-blue.svg?style=flat-square)](https://docs.rs/typed-session)
 
 Use typed-session to outsource all the low-level details of session management, such as session expiration and automatic renewal as well as change tracking of session data.
-Typed-session was designed with security, efficiency and usability in mind.
+Typed-session was designed with **security**, **efficiency** and **usability** in mind.
+Typed session is meant to act as a middleware in a web framework, injecting session information into HTTP requests as required, and storing sessions in a database.
 
-Currently, the following session stores are available:
+The documentation is available on [docs.rs](https://docs.rs/typed-session).
+
+Currently, the following **session stores** are available:
 
  * `MemoryStore`, a debug session store available under the feature flag `memory-store`.
 
-Currently, typed-session is integrated into the following web frameworks:
+Currently, typed-session is integrated into the following **web frameworks**:
 
  * none so far
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,7 @@
 //! [The OWASP® Foundation](https://owasp.org) recommends session ids to have at least
 //! [`128` bits of entropy](https://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html#session-id-entropy).
 //! That is, `64` bits of actual entropy, where a good PRNG is assumed to produce `0.5` bits of entropy per bit.
-//! The random source used by default is [`rand::rngs::ThreadRng`], version 0.8.5, which is _secure_.
+//! The random source used by default is [`rand::rngs::ThreadRng`], from the [rand] crate, which is secure.
 //!
 //! Session data is stored only in the session store, the client only stores the unhashed session id.
 //! The session store only stores the hashed session id.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,8 +55,7 @@
 //!
 //! Sessions are identified by an alphanumeric string including upper and lower case letters from the
 //! English alphabet. This gives `log_2(26+26+10) ≥ 5.95` bits of entropy per character. The default
-//! cookie length is `64`, resulting in `log_2(26+26+10) * 64 ≥ 381` bits of entropy. If a cookie
-//! length of `32` is used, then the cookie contains `log_2(26+26+10) * 32 ≥ 190` bits of entropy.
+//! cookie length is `32`, resulting in `log_2(26+26+10) * 32 ≥ 190` bits of entropy.
 //! [The OWASP® Foundation](https://owasp.org) recommends session ids to have at least
 //! [`128` bits of entropy](https://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html#session-id-entropy).
 //! That is, `64` bits of actual entropy, where a good PRNG is assumed to produce `0.5` bits of entropy per bit.

--- a/src/session.rs
+++ b/src/session.rs
@@ -9,10 +9,11 @@ use std::mem;
 ///
 /// `SessionData` is the data associated with a session.
 /// `COOKIE_LENGTH` is the length of the session cookie, in characters.
+/// The default choice is 32, which is secure.
 /// It should be a multiple of 32, which is the block size of blake3.
 #[derive(Debug, Clone)]
 #[must_use]
-pub struct Session<SessionData, const COOKIE_LENGTH: usize = 64> {
+pub struct Session<SessionData, const COOKIE_LENGTH: usize = 32> {
     pub(crate) state: SessionState<SessionData>,
 }
 
@@ -503,7 +504,8 @@ impl SessionId {
     /// This is automatically done by the [`SessionStore`](crate::SessionStore), and this function is only public for test purposes.
     pub fn from_cookie_value(cookie_value: &str) -> Self {
         // The original code used base64 encoded binary ids of length of a multiple of the blake3 block size.
-        // We do the same but with alphanumerical ids with a length multiple of the blake3 block size.
+        // We do the same, but instead of base64 encoding a binary ids, we use normal alphanumerical ids with a length multiple of the blake3 block size.
+        // This gives less entropy, but still more than enough to be secure (see crate-level documentation).
         let hash = blake3::hash(cookie_value.as_bytes());
         Self(Box::new(hash.into()))
     }

--- a/src/session_store.rs
+++ b/src/session_store.rs
@@ -17,13 +17,14 @@ pub(crate) mod cookie_generator;
 /// `SessionData` is the data associated with a session.
 /// `SessionStoreConnection` is the connection to the backend session store.
 /// `COOKIE_LENGTH` is the length of the session cookie, in characters.
+/// The default choice is 32, which is secure.
 /// It should be a multiple of 32, which is the block size of blake3.
 /// `CookieGenerator` is the type used to generate random session cookies.
 #[derive(Debug)]
 pub struct SessionStore<
     SessionData,
     SessionStoreConnection,
-    const COOKIE_LENGTH: usize = 64,
+    const COOKIE_LENGTH: usize = 32,
     CookieGenerator = DefaultSessionCookieGenerator<COOKIE_LENGTH>,
 > {
     implementation: SessionStoreConnection,

--- a/src/session_store/cookie_generator/mod.rs
+++ b/src/session_store/cookie_generator/mod.rs
@@ -12,7 +12,7 @@ pub trait SessionCookieGenerator<const COOKIE_LENGTH: usize> {
 /// It uses [`ThreadRng`](rand::rngs::ThreadRng) as a random source and the [`Alphanumeric`] distribution
 /// to generate cookie strings. This gives `log_2(26+26+10) ≥ 5.95` bits of entropy per character.
 #[derive(Debug, Default, Clone)]
-pub struct DefaultSessionCookieGenerator<const COOKIE_LENGTH: usize = 64>;
+pub struct DefaultSessionCookieGenerator<const COOKIE_LENGTH: usize = 32>;
 
 impl<const COOKIE_LENGTH: usize> SessionCookieGenerator<COOKIE_LENGTH>
     for DefaultSessionCookieGenerator<COOKIE_LENGTH>

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -7,7 +7,7 @@ use typed_session::{
 /// If a new session is created but never mutated, then no cookie is set and the session is not stored in the session store.
 #[async_std::test]
 async fn test_dont_store_default_session() {
-    let mut store: SessionStore<(), _, 64, _> = SessionStore::new_with_cookie_generator(
+    let mut store: SessionStore<(), _, 32, _> = SessionStore::new_with_cookie_generator(
         MemoryStore::new_with_logger(),
         DebugSessionCookieGenerator::default(),
         SessionRenewalStrategy::Ignore,
@@ -26,10 +26,10 @@ async fn test_dont_store_default_session() {
 /// If a new session is created and mutated, then a cookie is set and the session is stored in the session store.
 #[async_std::test]
 async fn test_store_updated_default_session() {
-    let mut cookie_generator = DebugSessionCookieGenerator::<64>::default();
+    let mut cookie_generator = DebugSessionCookieGenerator::<32>::default();
     let cookie_0 = cookie_generator.generate_cookie();
 
-    let mut store: SessionStore<i32, _, 64, _> = SessionStore::new_with_cookie_generator(
+    let mut store: SessionStore<i32, _, 32, _> = SessionStore::new_with_cookie_generator(
         MemoryStore::new_with_logger(),
         DebugSessionCookieGenerator::default(),
         SessionRenewalStrategy::Ignore,
@@ -64,10 +64,10 @@ async fn test_store_updated_default_session() {
 /// If a session is loaded from the store and stored without change, then the cookie is not updated and the session is not updated in the session store.
 #[async_std::test]
 async fn test_dont_update_unchanged_session() {
-    let mut cookie_generator = DebugSessionCookieGenerator::<64>::default();
+    let mut cookie_generator = DebugSessionCookieGenerator::<32>::default();
     let cookie_0 = cookie_generator.generate_cookie();
 
-    let mut store: SessionStore<i32, _, 64, _> = SessionStore::new_with_cookie_generator(
+    let mut store: SessionStore<i32, _, 32, _> = SessionStore::new_with_cookie_generator(
         MemoryStore::new_with_logger(),
         DebugSessionCookieGenerator::default(),
         SessionRenewalStrategy::Ignore,
@@ -99,10 +99,10 @@ async fn test_dont_update_unchanged_session() {
 /// If a session is loaded from the store and stored with change, then the cookie is updated and the session is updated in the session store.
 #[async_std::test]
 async fn test_update_changed_session() {
-    let mut cookie_generator = DebugSessionCookieGenerator::<64>::default();
+    let mut cookie_generator = DebugSessionCookieGenerator::<32>::default();
     let cookie_0 = cookie_generator.generate_cookie();
     let cookie_1 = cookie_generator.generate_cookie();
-    let mut store: SessionStore<i32, _, 64, _> = SessionStore::new_with_cookie_generator(
+    let mut store: SessionStore<i32, _, 32, _> = SessionStore::new_with_cookie_generator(
         MemoryStore::new_with_logger(),
         DebugSessionCookieGenerator::default(),
         SessionRenewalStrategy::Ignore,


### PR DESCRIPTION
This is still more than secure, according to OWASP.